### PR TITLE
Modify: APSS sensor, seneor ID and dimm-thermal.i2c

### DIFF
--- a/mowgli.xml
+++ b/mowgli.xml
@@ -5425,6 +5425,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/apss-0/apss.GPIO13</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/apss-0/apss.GPIO14</id>
 	<property>
 	<id>DIRECTION</id>
@@ -5943,7 +5950,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x32</value>
+	<value>0x34</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -6573,7 +6580,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x34</value>
+	<value>0x38</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -6662,7 +6669,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x36</value>
+	<value>0x3C</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -9990,7 +9997,7 @@
 	<id>/sys-0/ps_redundancy_state_sensor</id>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0x0B</value>
+	<value>0x09</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -10005,6 +10012,27 @@
 	<property>
 	<id>IPMI_SENSOR_ID</id>
 	<value>0xE7</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/power_cap_sensor</id>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0x04</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/dimm_freq_sensor</id>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0x05</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/apss_fault_sensor</id>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0x07</value>
 	</property>
 </globalSetting>
 </globalSettings>
@@ -62832,7 +62860,7 @@
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_ID</id>
-		<default>10</default>
+		<default>16</default>
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_OFFSET</id>
@@ -62892,7 +62920,7 @@
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
-		<default>NA</default>
+		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
 		<id>OFFSET</id>
@@ -62927,7 +62955,7 @@
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_ID</id>
-		<default>12</default>
+		<default>18</default>
 	</attribute>
 	<attribute>
 		<id>ADC_CHANNEL_OFFSET</id>
@@ -62987,7 +63015,7 @@
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
-		<default>NA</default>
+		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
 		<id>OFFSET</id>


### PR DESCRIPTION
-Add the sensor ID of power_cap_sensor, dimm_freq_sensor and apss_fault_sensor.
-Add two APSS sensors: STORAGE and FAN.
-Modify the thermal I2C address of dimm.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>